### PR TITLE
FOSSGIS Events

### DIFF
--- a/content/news/fossgis-events-2020.md
+++ b/content/news/fossgis-events-2020.md
@@ -12,5 +12,5 @@ Das Ereignis des Jahres 2020 rund um **F**reie **O**pen **S**ource **S**oftware 
  * [FOSS4G Europe 2020 in Valmiera (Lettland)](https://2020.europe.foss4g.org/) (13.-18.07.2020)
  * [FOSS4G 2020 in Calgary (Alberta, Canada)](https://2020.foss4g.org/) (24.8.-29.08.2020)
   
-Eine vollst&auml;ndige &Uuml;bersicht &uuml;ber die Veranstaltungen zu OpenStreetMap gibt es im [OSM-Kalender](https://wiki.openstreetmap.org/wiki/Current_events) OSM-Kalender.
-Auch die  OSGeo verf&uuml;gt &uuml;ber eine Veranstaltungs&uuml;bersicht: [OSGeo Events](https://www.osgeo.org/events/) OSGeo Events.
+Eine vollst&auml;ndige &Uuml;bersicht &uuml;ber die Veranstaltungen zu OpenStreetMap gibt es im [OSM-Kalender](https://wiki.openstreetmap.org/wiki/Current_events).
+Auch die  OSGeo verf&uuml;gt &uuml;ber eine Veranstaltungs&uuml;bersicht: [OSGeo Events](https://www.osgeo.org/events/).

--- a/content/news/fossgis-events-2020.md
+++ b/content/news/fossgis-events-2020.md
@@ -1,0 +1,16 @@
+---
+title: "FOSSGIS Events 2020"
+date: "2020-02-22T14:00:00+02:00"
+author: "Oliver Rudzick"
+---
+Das Ereignis des Jahres 2020 rund um **F**reie **O**pen **S**ource **S**oftware für **G**eo**I**nformations**S**ysteme ist in Deutschland nat&uuml;rlich die [FOSSGIS-Konferenz 2020](https://www.fossgis-konferenz.de/2020/) (11.-14.3.2020) in Freiburg. Dar&uuml;ber hinaus gibt es viele andere, nicht weniger interessante Veranstaltungen. Hier ist eine kleine Auswahl:
+
+ * [Deutschsprachige PostgreSQL Konferenz in Stuttgart](https://2020.pgconf.de/) (15.05.2020)
+ * [State of the Map France 2020 in Nantes (Frankreich)](https://sotm2020.openstreetmap.fr/) (12.06.-14.06.2020)
+ * [State of the Map 2020 in Kapstadt (Südafrika)](https://2020.stateofthemap.org/) (03.-05.07.2020)
+ * [AGIT 2020 in Salzburg (&Ouml;sterreich](https://www.agit.at/) (08.07.-10.07.2020)
+ * [FOSS4G Europe 2020 in Valmiera (Lettland)](https://2020.europe.foss4g.org/) (13.-18.07.2020)
+ * [FOSS4G 2020 in Calgary (Alberta, Canada)](https://2020.foss4g.org/) (24.8.-29.08.2020)
+  
+Eine vollst&auml;ndige &Uuml;bersicht &uuml;ber die Veranstaltungen zu OpenStreetMap gibt es im [OSM-Kalender](https://wiki.openstreetmap.org/wiki/Current_events) OSM-Kalender.
+Auch die  OSGeo verf&uuml;gt &uuml;ber eine Veranstaltungs&uuml;bersicht: [OSGeo Events](https://www.osgeo.org/events/) OSGeo Events.

--- a/content/news/fossgis-events.md
+++ b/content/news/fossgis-events.md
@@ -1,5 +1,5 @@
 ---
-title: "FOSSGIS Events 2020"
+title: "FOSSGIS Events"
 date: "2020-02-22T14:00:00+02:00"
 author: "Oliver Rudzick"
 ---
@@ -8,7 +8,7 @@ Das Ereignis des Jahres 2020 rund um **F**reie **O**pen **S**ource **S**oftware 
  * [Deutschsprachige PostgreSQL Konferenz in Stuttgart](https://2020.pgconf.de/) (15.05.2020)
  * [State of the Map France 2020 in Nantes (Frankreich)](https://sotm2020.openstreetmap.fr/) (12.06.-14.06.2020)
  * [State of the Map 2020 in Kapstadt (Südafrika)](https://2020.stateofthemap.org/) (03.-05.07.2020)
- * [AGIT 2020 in Salzburg (&Ouml;sterreich](https://www.agit.at/) (08.07.-10.07.2020)
+ * [AGIT 2020 in Salzburg (&Ouml;sterreich)](https://www.agit.at/) (08.07.-10.07.2020)
  * [FOSS4G Europe 2020 in Valmiera (Lettland)](https://2020.europe.foss4g.org/) (13.-18.07.2020)
  * [FOSS4G 2020 in Calgary (Alberta, Canada)](https://2020.foss4g.org/) (24.8.-29.08.2020)
   


### PR DESCRIPTION
Eine Seite mit kommenden Veranstaltungen zu FOSSGIS und OSM erstellt. Sie könnte als "kommende Veranstaltungen" o. ä. auf der Fossgis Homepage verlinkt werden und regelmäßig aktualisiert werden: content/news/fossgis-events.md