### PR TITLE
Eigene Seite für Neuigkeiten jeden Jahres

### DIFF
--- a/content/news/2009/_index.md
+++ b/content/news/2009/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2009"
+layout: year
+---

--- a/content/news/2010/_index.md
+++ b/content/news/2010/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2010"
+layout: year
+---

--- a/content/news/2011/_index.md
+++ b/content/news/2011/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2011"
+layout: year
+---

--- a/content/news/2012/_index.md
+++ b/content/news/2012/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2012"
+layout: year
+---

--- a/content/news/2013/_index.md
+++ b/content/news/2013/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2013"
+layout: year
+---

--- a/content/news/2014/_index.md
+++ b/content/news/2014/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2014"
+layout: year
+---

--- a/content/news/2015/_index.md
+++ b/content/news/2015/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2015"
+layout: year
+---

--- a/content/news/2016/_index.md
+++ b/content/news/2016/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2016"
+layout: year
+---

--- a/content/news/2017/_index.md
+++ b/content/news/2017/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2017"
+layout: year
+---

--- a/content/news/2018/_index.md
+++ b/content/news/2018/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2018"
+layout: year
+---

--- a/content/news/2019/_index.md
+++ b/content/news/2019/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2019"
+layout: year
+---

--- a/content/news/2020/_index.md
+++ b/content/news/2020/_index.md
@@ -1,0 +1,4 @@
+---
+title: "2020"
+layout: year
+---

--- a/themes/fossgis/assets/css/style.css
+++ b/themes/fossgis/assets/css/style.css
@@ -157,3 +157,15 @@ footer {
     border-bottom: 1px solid grey;
 }
 
+div.news-year-list {
+    margin-top: 4px;
+}
+
+div.news-year-list span, div.news-year-list a {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    padding: 2px;
+    margin-right: 4px;
+    text-decoration: none;
+}
+

--- a/themes/fossgis/layouts/news/year.html
+++ b/themes/fossgis/layouts/news/year.html
@@ -1,0 +1,35 @@
+{{ define "title" }}
+    Neuigkeiten {{ .Title }} &ndash; {{ .Site.Title }}
+{{ end }}
+
+{{ define "main" }}
+<content id="main-content">
+    {{ $year := int .Title }}
+    <div class="news-year-list">
+        {{ range seq now.Year 2009 }}
+            {{ if eq . $year }}
+                <span>{{ . }}</span>
+            {{- else -}}
+                <a href="/news/{{ . }}/">{{ . }}</a>
+            {{- end -}}
+        {{ end }}
+    </div>
+    <h1>Neuigkeiten {{ $year }}</h1>
+    {{ range where .Site.Pages "Section" "news" }}
+        {{ if eq .Date.Year $year }}
+        <article class="row">
+            <div class="col-sm-2 last-xs first-sm article-meta">
+                {{ .Date.Format "02.01.2006" }}<br>
+                {{ .Params.Author }}
+            </div>
+
+            <div class="col-xs-12 col-sm-10">
+                <a href="{{ .RelPermalink }}"><h2>{{ .Title }}</h2></a>
+                {{ .Summary }}
+                <br><a href="{{ .RelPermalink }}">Ganzen Beitrag lesen »</a>
+            </div>
+        </article>
+        {{ end }}
+    {{ end }}
+</content>
+{{ end }}


### PR DESCRIPTION
Ich habe mal Seiten gebaut, wo man die News nach Jahren sehen kann. Leider habe ich keinen Weg gefunden, wie man das machen kann, ohne für jedes Jahr ein File anzulegen.

@thomersch Vielleicht hast Du ja eine bessere Idee?

Im Moment sind die neuen Seiten so noch nicht verlinkt. Man muss also über die URL `/news/JAHR/` darauf zugreifen. Weiß noch nicht genau, wie man das am besten macht. Entweder `/news/` redirected einfach auf `/news/AKTUELLES_JAHR` oder wir belassen `/news/` als eigene Seite, die die letzten 10 oder so darstellt, aber auch dieses Menu oben hat mit den Jahreszahlen.