### PR TITLE
ag diestleistende: fixing typos

### DIFF
--- a/content/arbeitsgruppen/dienstleisterliste.md
+++ b/content/arbeitsgruppen/dienstleisterliste.md
@@ -9,10 +9,9 @@ menu:
 Die Arbeitsgruppe "Arbeitsgruppe Liste der Dienstleistenden im Open Source und Open Data Bereich" hat es sich zur Aufgabe gemacht eine Liste von Dienstleistenden zu entwickeln, mit dem Ziel möglichst neutral und offen über Dienstleistende zu informieren. 
 
 ## Mitglieder
-- Dominik Hellde
-- Jörg Thomasen
+- Dominik Helle
+- Jörg Thomsen
 - Lars Lingner
-- Antje Gerstenberger
 - Katja Haferkorn
 
 Weitere Informationen im [Wiki](https://www.fossgis.de/wiki/Arbeitsgruppe_Dienstleistende).


### PR DESCRIPTION
Namen auf der AG-Seite korrigiert