### PR TITLE
AG OSM-Langzeitarchivierung auf der FOSSGIS-Webseite verlinkt

### DIFF
--- a/content/arbeitsgruppen/_index.md
+++ b/content/arbeitsgruppen/_index.md
@@ -31,6 +31,9 @@ Die [Arbeitsgruppe](/arbeitsgruppen/dienstleisterliste) hat es sich zur Aufgabe 
 ## Arbeitsgruppe "Öffentliche Ausschreibungen mit FOSS"
 Die [Arbeitsgruppe](/arbeitsgruppen/ag_agiles_vorgehen) "öffentliche Ausschreibungen mit FOSS" hat das Ziel Informationen zusammenzustellen, die hilfreich sind, um die öffentliche Hand bei Ausschreibungen zu unterstützen, die zum Ziel haben, Open Source Software zu implementieren und in die Nutzung zu bringen. 
 
+## Arbeitsgruppe "OSM-Langzeitarchivierung"
+Diese [Arbeitsgruppe](https://www.fossgis.de/wiki/OSM_Langzeitarchivierung) beschäftigt sich mit Fragestellungen im Zusammenhang mit der dauerhaften Archivierung und Verfügbarmachung von OpenStreetMap-Daten. Ziel ist es, OpenStreetMap als Teil des kartographischen Weltkulturerbes in seiner kulturgeschichtlichen Entwicklung einer breiten wissenschaftlichen Community zugänglich zu machen.
+
 ## Arbeitsgruppe "CRA"
 
 Die Arbeitsgruppe befinden sich gerade im Aufbau. Vorläufige Informationen

--- a/content/impressum/_index.md
+++ b/content/impressum/_index.md
@@ -13,9 +13,9 @@ aliases:
 
 ## Vertreten durch
 
-* N. N.
 * Pirmin Kalberer
-* David Arndt
+* Jannik Schilling
+* Florian Thiery
 * Falk Zscheile
 
 ## Kontakt

--- a/content/verein/vorstand/_index.md
+++ b/content/verein/vorstand/_index.md
@@ -9,9 +9,9 @@ menu:
 Der Vorstand des FOSSGIS e.V. wird aller zwei Jahre auf der Mitgliederversammlung
 gewählt. Zur Zeit besteht er aus:
 
-* N.N. (1. Vorsitz)
-* Pirmin Kalberer (2. Vorsitz)
-* David Arndt (Finanzen)
+* Pirmin Kalberer (1. Vorsitz)
+* Jannik Schilling (2. Vorsitz)
+* Florian Thiery (Finanzen)
 * Falk Zscheile (Schriftführer)
 
 ## Was macht der Vorstand?


### PR DESCRIPTION
AG OSM-Langzeitarchivierung auf der FOSSGIS-Webseite unter "Arbeitsgruppen" verlinkt.